### PR TITLE
CI - Build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,20 +150,32 @@ jobs:
             arch-type: Intel
             arch: "x86_64"
             build-type: "Release"
-    
+          - os: "windows-2022"
+            arch-type: Intel
+            arch: "x86_64"
+            build-type: "Release"
+
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      
-      # Build with Visual Studio 2019 (MSVC 14.2) to ensure plugin compatibility with Nuke 14-16+
-      - name: Configure MakeHDR
+
+      - name: Configure MakeHDR (VS2019)
+        if: matrix.os == 'windows-2019'
         run: |
           mkdir build
           cd build
           cmake --version
           cmake -G "Visual Studio 16 2019" -A x64 ..
+
+      - name: Configure MakeHDR (VS2022)
+        if: matrix.os == 'windows-2022'
+        run: |
+          mkdir build
+          cd build
+          cmake --version
+          cmake -G "Visual Studio 17 2022" -A x64 ..
 
       - name: Build MakeHDR
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,194 @@
+name: Build MakeHDR
+
+on:
+#   push:
+#     branches: [ main ]
+#   pull_request:
+#     branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  
+  linux:
+    name: '${{ matrix.os }} ${{ matrix.arch-type }}'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: "ubuntu-22.04" # ubuntu-latest
+            arch: x86_64
+            arch-type: Intel
+            build-type: "Release"
+    steps:
+
+      # Build with GCC 9 to ensure plugin compatibility with Nuke 14-16+
+      - name: Install GCC 9
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt-get update
+          sudo apt-get install -y gcc-9 g++-9
+
+      - name: Set GCC 9 as default
+        run: |
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 90
+          gcc --version
+          g++ --version
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Configure MakeHDR
+        run: |
+          mkdir build
+          cd build
+          cmake --version
+          cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++-9 ..
+
+      - name: Build MakeHDR
+        run: |
+          cd build
+          cmake --build . --parallel
+
+      - name: Install MakeHDR
+        run: |
+          cd build
+          cmake --install .
+  
+      - name: Create Archive of MakeHDR
+        run: |
+          cd build
+          zip -r "../MakeHDR-${{ matrix.os }}-${{ matrix.arch }}.zip" make_hdr.ofx.bundle
+          cd ..
+          ls -l
+
+      - name: Upload MakeHDR bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: MakeHDR-${{ matrix.os }}-${{ matrix.arch }}
+          path: MakeHDR-${{ matrix.os }}-${{ matrix.arch }}.zip
+          retention-days: 14
+          compression-level: 0
+
+  macos:
+    name: '${{ matrix.os }} ${{ matrix.arch-type }}'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: "macos-14"
+            arch: arm64
+            arch-type: Apple Silicon
+            build-type: "Release"
+          - os: "macos-13"
+            arch: x86_64
+            arch-type: Intel
+            build-type: "Release"
+    steps:
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      
+      # Build with Xcode 14 to ensure plugin compatibility with Nuke 14-16+
+      - name: Select Xcode version for Intel
+        if: matrix.arch-type == 'Intel'
+        run: sudo xcode-select -s /Applications/Xcode_14.1.0.app
+
+      - name: Configure MakeHDR for Intel
+        if: matrix.arch == 'x86_64'
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 -DCMAKE_OSX_ARCHITECTURES=x86_64 ..
+
+      - name: Configure MakeHDR for ARM
+        if: matrix.arch == 'arm64'
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 -DCMAKE_OSX_ARCHITECTURES=arm64 ..
+
+      - name: Build MakeHDR
+        run: |
+          cd build
+          cmake --build . --parallel
+
+      - name: Install MakeHDR
+        run: |
+          cd build
+          cmake --install .
+  
+      - name: Create Archive of MakeHDR
+        run: |
+          cd build
+          xattr -cr make_hdr.ofx.bundle
+          zip -r "../MakeHDR-${{ matrix.os }}-${{ matrix.arch }}.zip" make_hdr.ofx.bundle
+          cd ..
+          ls -l
+
+      - name: Upload MakeHDR bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: MakeHDR-${{ matrix.os }}-${{ matrix.arch }}
+          path: MakeHDR-${{ matrix.os }}-${{ matrix.arch }}.zip
+          retention-days: 14
+          compression-level: 0
+
+  windows:
+    name: '${{ matrix.os }} ${{ matrix.arch-type }}'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: "windows-2019"
+            arch-type: Intel
+            arch: "x86_64"
+            build-type: "Release"
+    
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      
+      # Build with Visual Studio 2019 (MSVC 14.2) to ensure plugin compatibility with Nuke 14-16+
+      - name: Configure MakeHDR
+        run: |
+          mkdir build
+          cd build
+          cmake --version
+          cmake -G "Visual Studio 16 2019" -A x64 ..
+
+      - name: Build MakeHDR
+        run: |
+          cd build
+          cmake --build . --parallel --config ${{ matrix.build-type }}
+        
+      - name: Install MakeHDR
+        run: |
+          cd build
+          cmake --install . --config ${{ matrix.build-type }}
+  
+      - name: Install zip using chocolatey
+        run: choco install zip -y
+        shell: powershell
+        
+      - name: Create Archive of MakeHDR
+        run: |
+          cd build
+          zip -r "../MakeHDR-${{ matrix.os }}-${{ matrix.arch }}.zip" make_hdr.ofx.bundle
+          cd..
+
+      - name: Upload MakeHDR bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: MakeHDR-${{ matrix.os }}-${{ matrix.arch }}
+          path: MakeHDR-${{ matrix.os }}-${{ matrix.arch }}.zip
+          retention-days: 14
+          compression-level: 0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ set_target_properties(make_hdr
 
 target_compile_definitions(make_hdr PRIVATE)
 
-install(TARGETS make_hdr DESTINATION ${INSTALL_BIN_PATH})
+#install(TARGETS make_hdr DESTINATION ${INSTALL_BIN_PATH})
+install(FILES $<TARGET_FILE:make_hdr> DESTINATION ${INSTALL_BIN_PATH})
+
 install(FILES ${CMAKE_SOURCE_DIR}/icons/net.sf.openfx.make_hdr.png DESTINATION ${INSTALL_RES_PATH})
 install(FILES ${CMAKE_SOURCE_DIR}/icons/net.sf.openfx.make_hdr.svg DESTINATION ${INSTALL_RES_PATH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ add_subdirectory(${CMAKE_SOURCE_DIR}/modules/openfx/Support/Library)
 
 add_library(make_hdr SHARED ${CMAKE_SOURCE_DIR}/source/effect.cpp)
 
+# Require C++14 standard for this target.
+set_target_properties(make_hdr PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED YES)
+
 target_link_libraries(make_hdr f2c)
 target_link_libraries(make_hdr blas)
 target_link_libraries(make_hdr lapack)
@@ -43,10 +46,18 @@ set_target_properties(make_hdr
 	SUFFIX ".ofx"
 	OUTPUT_NAME "make_hdr")
 
-target_compile_definitions(make_hdr PRIVATE)
+# MSVC/Windows-specific compile options and definitions.
+if (WIN32 AND MSVC)
+    target_compile_options(make_hdr PRIVATE /utf-8)
+    target_compile_definitions(make_hdr PRIVATE NOMINMAX)
+endif()
 
-#install(TARGETS make_hdr DESTINATION ${INSTALL_BIN_PATH})
+# Workaround for constexpr mutex constructor in MSVC 1930+ (Visual Studio 2019+).
+if (MSVC AND MSVC_VERSION GREATER_EQUAL 1930)
+    target_compile_definitions(make_hdr PRIVATE _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+endif()
+
+# Install the plugin binary and resource files.
 install(FILES $<TARGET_FILE:make_hdr> DESTINATION ${INSTALL_BIN_PATH})
-
 install(FILES ${CMAKE_SOURCE_DIR}/icons/net.sf.openfx.make_hdr.png DESTINATION ${INSTALL_RES_PATH})
 install(FILES ${CMAKE_SOURCE_DIR}/icons/net.sf.openfx.make_hdr.svg DESTINATION ${INSTALL_RES_PATH})


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow that automatically builds the plugin for multiple platforms, following Foundry's OFX plugin compatibility recommendations.

Cross-platform builds on:

- Linux (Ubuntu 22.04) with GCC 9
- macOS with builds for:
  - Intel (x86_64) on macOS 13 (Optional)
  - Apple Silicon (arm64) on macOS 14
- Windows using Visual Studio 2019

Notes:

- The workflow runs on manual trigger (workflow_dispatch) for now
- Artifacts are available for 14 days after workflow completion

Successfully tested with Nuke 16.0v1 on Windows 11 as well as Natron on macOS, Linux Mint and Windows. The plugin even works fine when compiled using the latest OS runners e.g. `macOS-latest` with Natron (but crashes Nuke 16.0v1 when compiling with later versions of Visual Studio). If there's anything I missed though or something to improve on, please just let me know.

Cheers,
Christian

PS: Thanks for this plugin and your effort you put into it.
