### PR TITLE
Houdini compatibility

### DIFF
--- a/source/effect.cpp
+++ b/source/effect.cpp
@@ -250,15 +250,17 @@ void EffectPluginFactory::describeInContext(OFX::ImageEffectDescriptor& desc, OF
     // Setup inputs
     for (int i = 0; i < SRC_MAX; ++i)
     {
-        const std::string src_name = std::to_string(i + 1);
+        const std::string src_name = "src" + std::to_string(i + 1);
 
         OFX::ClipDescriptor* src_clip = desc.defineClip(src_name);
         src_clip->addSupportedComponent(OFX::ePixelComponentRGBA);
+        src_clip->setLabels(std::to_string(i + 1), std::to_string(i + 1), std::to_string(i + 1));
 
         if (i > 0)
             src_clip->setOptional(true);
 
         OFX::DoubleParamDescriptor* exp_times_param = desc.defineDoubleParam(src_name);
+        exp_times_param->setLabels(std::to_string(i + 1), std::to_string(i + 1), std::to_string(i + 1));
         exp_times_param->setDisplayRange(0, 1);
         exp_times_param->setHint("Shutter speed of corresponding source in seconds");
         exp_times_param->setParent(*exposure_times_group);

--- a/source/effect.h
+++ b/source/effect.h
@@ -19,7 +19,7 @@ public:
     {
         for (int i = 0; i < SRC_MAX; ++i)
         {
-            std::string src_name = std::to_string(i + 1);
+            std::string src_name = "src" + std::to_string(i + 1);
 
             _src_clips.push_back(fetchClip(src_name));
             _exp_times.push_back(fetchDoubleParam(src_name));


### PR DESCRIPTION
This tiny little PR makes the plugin compatible with Houdini:

<img width="1919" height="1095" alt="Screenshot 2026-04-29 175407" src="https://github.com/user-attachments/assets/e7cff4e1-d3c1-4342-9767-aaafcaf3bd9c" /><br>

Houdini's parser seems to crash when it encounters OFX parameters that start with numbers. I updated the internal identifiers to use a "src" prefix ("src1") while using `setLabels()` to ensure the UI still displays them as "1", "2", etc as usual.

What do you think?

P.S. That's the last one from me today! No rush on the reviews—just wanted to get them off my plate.

Cheers,
Christian