### PR TITLE
Documentation updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
   
       - name: Fix Permissions
         run: |
-          xattr -cr ${{ env.LOCAL_PLUGIN_PATH }}/make_hdr.ofx.bundle
+          xattr -cr ${{ env.LOCAL_PLUGIN_PATH }}/MakeHDR.ofx.bundle
 
       - name: Upload MakeHDR bundle
         uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,25 +8,25 @@ option(USE_ACCELERATE "Use macOS Accelerate framework instead of clapack" OFF)
 
 if (WIN32)
 	set(OFX_PLUGIN_PATH "C:/Program Files/Common Files/OFX/Plugins" CACHE PATH "OFX Plugin Install Path")
-	set(INSTALL_BIN_PATH ${OFX_PLUGIN_PATH}/make_hdr.ofx.bundle/Contents/Win64)
+	set(INSTALL_BIN_PATH ${OFX_PLUGIN_PATH}/MakeHDR.ofx.bundle/Contents/Win64)
 	if(MSVC)
 		add_compile_options(/MP)
 	endif()
 
 elseif (APPLE)
 	set(OFX_PLUGIN_PATH "/Library/OFX/Plugins" CACHE PATH "OFX Plugin Install Path")
-	set(INSTALL_BIN_PATH ${OFX_PLUGIN_PATH}/make_hdr.ofx.bundle/Contents/MacOS)
+	set(INSTALL_BIN_PATH ${OFX_PLUGIN_PATH}/MakeHDR.ofx.bundle/Contents/MacOS)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -include stdio.h")
 
 elseif (UNIX)
 	set(OFX_PLUGIN_PATH "/usr/OFX/Plugins" CACHE PATH "OFX Plugin Install Path")
-	set(INSTALL_BIN_PATH ${OFX_PLUGIN_PATH}/make_hdr.ofx.bundle/Contents/Linux-x86-64)
+	set(INSTALL_BIN_PATH ${OFX_PLUGIN_PATH}/MakeHDR.ofx.bundle/Contents/Linux-x86-64)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 endif()
 
-set(INSTALL_RES_PATH ${OFX_PLUGIN_PATH}/make_hdr.ofx.bundle/Contents/Resources)
+set(INSTALL_RES_PATH ${OFX_PLUGIN_PATH}/MakeHDR.ofx.bundle/Contents/Resources)
 
 include_directories(${CMAKE_SOURCE_DIR}/source)
 include_directories(${CMAKE_SOURCE_DIR}/modules/openfx/include)
@@ -81,7 +81,7 @@ set_target_properties(make_hdr
 	CXX_STANDARD_REQUIRED YES
 	PREFIX ""
 	SUFFIX ".ofx"
-	OUTPUT_NAME "make_hdr")
+	OUTPUT_NAME "MakeHDR")
 
 find_package(Nuke)
 

--- a/README.md
+++ b/README.md
@@ -1,49 +1,69 @@
-# MakeHDR 
+# MakeHDR
 
-![plot](./icons/net.sf.openfx.make_hdr.png)
+![MakeHDR icon](./icons/net.sf.openfx.make_hdr.png)
 
 MakeHDR is an OpenFX plug-in for merging multiple LDR images into a single HDRI.
 
-## Feature notes
+## Feature Notes
+
 * Merge up to 16 inputs with 8, 10 or 12 bit depth processing
-* User friendly logarithmic Tone Mapping controls within the tool
-* Advanced controls such as Sampling rate and Smoothness
+* User-friendly logarithmic tone-mapping controls
+* Advanced controls such as sampling rate and smoothness
 
-Available at cross platform on Linux, MacOS and Windows
-Works consistent in compositing applications like Nuke, Fusion, Natron. 
+Available cross‑platform on Linux, macOS, and Windows; works consistently in compositing applications such as Nuke, Fusion, and Natron.
 
-## How to Build and Install
-```
+## Installation
+
+Download the [latest release](https://github.com/sosoyan/make-hdr/releases) and copy the `MakeHDR.ofx.bundle` directory to your custom `OFX_PLUGIN_PATH` or your system's default OpenFX plugin folder:
+
+* Linux: `/usr/OFX/Plugins`
+* macOS: `/Library/OFX/Plugins`
+* Windows: `C:\Program Files\Common Files\OFX\Plugins`
+
+## How to Use
+
+1. Create a `MakeHDR` node within your DCC app.
+2. Connect your source images, shot with multiple shutter speeds.
+3. Fill in the exposure times in seconds for the appropriate inputs (e.g., for a 1/250 shutter speed, enter 0.004).
+
+[![Create ACES HDRIs in NukeX using MakeHDR and CaraVR](https://img.youtube.com/vi/yTeBWqiZiTs/mqdefault.jpg)](https://www.youtube.com/watch?v=yTeBWqiZiTs)
+
+## Build from Source
+
+If you prefer to compile the plugin yourself, ensure you have CMake ≥ 3.5 and a C++14-compatible compiler ready on your system. Then run:
+
+```sh
 git clone --recursive https://github.com/sosoyan/make-hdr.git
 cd make-hdr && mkdir build && cd build
 cmake .. && sudo make install
 ```
 
-## How to Install manually
-Copy make_hdr.ofx.bundle directory to your system's default OFX_PLUGIN_PATH or where the environment variable is set to.
-- Linux: /usr/OFX/Plugins
-- MacOS: /Library/OFX/Plugins
-- Windows: C:\Program Files\Common Files\OFX\Plugins
+## Parameter Reference
 
-## How to Use
-1. Create MakeHDR node within your DCC app.
-2. Connect your source images shot with multiple shutter speed up to 16 inputs.
-3. Fill the details of exposure times in seconds for appropriate inputs, i.e. for 1/250 shutter speed enter 0.004.
+### Exposure Times
 
-[![Create ACES HDRIs in NukeX using MakeHDR and CaraVR](https://img.youtube.com/vi/yTeBWqiZiTs/0.jpg)](https://www.youtube.com/watch?v=yTeBWqiZiTsE)
+| Parameter | Description |
+|----------:|:------------|
+| `calibrate response` | Estimates the non-linear response curve from the source images. When disabled, assumes the source images are already linear. |
+| `1–16` | Defines the exposure time in seconds for each corresponding connected image source. |
 
-## Node Parameters Reference
-exposure_times
-- 1-16: Shutter speeds of corresponding source input in seconds
+### Tone Mapping
 
-tone_mapping
-- exposure: Exposure aka f-stop offset
-- gamma: Gamma correction
-- highlights: Logarithmic highlights compensation
+| Parameter | Description |
+|----------:|:------------|
+| `target middle gray` | Automatically adjusts global exposure so the average scene luminance matches the `middle gray` value. |
+| `middle gray` | Defines a reference gray from the scene (e.g., sampled from a colour checker) to scale the merged image's luminance. |
+| `exposure` | Applies a global exposure adjustment in stops to the merged HDR image before tone mapping. |
+| `gamma` | Applies a gamma exponent per-pixel after HDR merging, where 1.0 keeps linear output. |
+| `highlights` | Blends between fully compressed (0) and uncompressed linear (1) output. Lower values roll off bright areas more aggressively. |
 
-advanced
-- show samples: Show sample pixels for debugging purposes.
-- input depth: 8, 10 or 12 bit input image processing.
-- sampling: Sampling count squared, 8 means 64 total samples.
-- smoothness: Normalized smoothing of the response curve.
-- log level: Log verbosity level of the node
+### Advanced
+
+| Parameter | Description |
+|----------:|:------------|
+| `show samples` | Displays the sample positions on the output image as bright green pixels. |
+| `samples` | Defines the number of calibration samples. For `Debevec`, it specifies the exact number of points. For `Robertson`, the value is multiplied by 100 to compensate for sparse bin coverage. |
+| `solver` | [Debevec](https://www.pauldebevec.com/Research/HDR/) solves a linear system (fast, sparse samples). [Robertson](https://doi.org/10.1109/ICIP.1999.817091) uses an iterative expectation-maximisation approach. |
+| `smoothness / iterations` | For `Debevec`, higher values force a smoother response curve. For `Robertson`, it sets the maximum number of expectation-maximisation iterations. |
+| `input depth` | Determines the internal histogram resolution (`256`, `1024`, or `4096` bins). Match this to your camera's original bit depth. |
+| `log level` | Controls plugin logging verbosity. `off` silences all logging, while `debug` prints detailed per-frame diagnostics. |

--- a/source/resources.h
+++ b/source/resources.h
@@ -26,7 +26,7 @@
 #include "ofxsProcessing.H"
 
 #define VERSION_MAJOR 1
-#define VERSION_MINOR 2
+#define VERSION_MINOR 4
 #define VERSION_FIX 0
 
 #define CMP_MAX 3


### PR DESCRIPTION
Hi @sosoyan,

thanks for the new release! Forgot to update the readme last time, so this PR updates the documentation, bumps the version (mainly for consistency when running the CI), and renames the exported plugin bundle from `make_hdr.ofx.bundle` to `MakeHDR.ofx.bundle` to match the branding and instructions.

What do you think?

Cheers,
Christian 

p.s. I think the readme would be even nicer without the table headers, but it seems that's not possible with standard Markdown and I felt that using HTML is a bit overkill.