### PR TITLE
Mechanical cosmetics

### DIFF
--- a/source/effect.cpp
+++ b/source/effect.cpp
@@ -46,7 +46,7 @@ void Effect<ptype>::render(const OFX::RenderArguments& args)
         }
     }
     else
-        spdlog::error("[{}] destination must have RGBA components!", fx::label);
+        spdlog::error("[{}] destination must have RGBA components!", makehdr::label);
 }
 
 template <class ptype>
@@ -89,20 +89,20 @@ void Effect<ptype>::process(Processor<ptype>& processor, const OFX::RenderArgume
                                 processor.add_exp_time(exp_time);
                             }
                             else
-                                spdlog::warn("[{}] source {} bounds does not match the destination, skipping!", fx::label, i + 1);
+                                spdlog::warn("[{}] source {} bounds does not match the destination, skipping!", makehdr::label, i + 1);
                         }
                         else
                             OFX::throwSuiteStatusException(kOfxStatErrUnsupported);
                     }
                     else
-                        spdlog::debug("[{}] source image is empty!", fx::label);
+                        spdlog::debug("[{}] source image is empty!", makehdr::label);
                 }
                 else
-                    spdlog::warn("[{}] source {} exposure time is not set (= {}), skipping!", fx::label, i + 1, exp_time);
+                    spdlog::warn("[{}] source {} exposure time is not set (= {}), skipping!", makehdr::label, i + 1, exp_time);
             }
         }
 
-        spdlog::debug("[{}] processing frame {}, render window ({}, {}, {}, {})", fx::label,
+        spdlog::debug("[{}] processing frame {}, render window ({}, {}, {}, {})", makehdr::label,
             args.time,
             args.renderWindow.x1,
             args.renderWindow.x2,
@@ -118,7 +118,7 @@ void Effect<ptype>::process(Processor<ptype>& processor, const OFX::RenderArgume
         processor.process();
     }
     else
-        spdlog::error("[{}] destination image is empty!", fx::label);
+        spdlog::error("[{}] destination image is empty!", makehdr::label);
 }
 
 template<class ptype>
@@ -168,9 +168,9 @@ void Effect<ptype>::set_input_weights(int size)
 
 void EffectPluginFactory::describe(OFX::ImageEffectDescriptor& desc)
 {
-    desc.setLabels(fx::label, fx::label, fx::label);
+    desc.setLabels(makehdr::label, makehdr::label, makehdr::label);
     desc.setVersion(VERSION_MAJOR, VERSION_MINOR, VERSION_FIX, 0, "");
-    desc.setPluginDescription(fx::description);
+    desc.setPluginDescription(makehdr::description);
     desc.setPluginGrouping("OFX");
 
     desc.addSupportedContext(OFX::eContextFilter);

--- a/source/effect.cpp
+++ b/source/effect.cpp
@@ -67,7 +67,7 @@ void Effect<ptype>::process(Processor<ptype>& processor, const OFX::RenderArgume
 
             if (src_clip != nullptr && src_clip->isConnected())
             {
-                const float exp_time = (float)_exp_times[i]->getValueAtTime(args.time);
+                const float exp_time = static_cast<float>(_exp_times[i]->getValueAtTime(args.time));
 
                 if (exp_time > 0)
                 {
@@ -162,7 +162,7 @@ void Effect<ptype>::set_input_weights(int size)
         _input_weights.resize(size);
 
         for (int i = 0; i < size; ++i)
-            _input_weights[i] = (float)std::min(i, size - 1 - i);
+            _input_weights[i] = static_cast<float>(std::min(i, size - 1 - i));
     }
 }
 

--- a/source/effect.h
+++ b/source/effect.h
@@ -8,9 +8,8 @@
 #ifndef effect_h
 #define effect_h
 
+#include "resources.h"
 #include "processor.h"
-#include <unordered_set>
-#include <cstdint>
 
 
 template <class ptype>

--- a/source/effect.h
+++ b/source/effect.h
@@ -34,7 +34,7 @@ public:
     {
     }
 
-    virtual void changedParam(const OFX::InstanceChangedArgs& args, const std::string& paramName);
+    virtual void changedParam(const OFX::InstanceChangedArgs& args, const std::string& param_name);
     virtual void render(const OFX::RenderArguments& args);
 
     void process(Processor<ptype>& processor, const OFX::RenderArguments& args);
@@ -46,7 +46,7 @@ public:
 
     const std::vector<float>& input_weights() { return _input_weights; }
 
-    std::vector<fx::point>& sample_points() { return _sample_points; }
+    std::vector<makehdr::point>& sample_points() { return _sample_points; }
     std::unordered_set<int64_t>& sample_set() { return _sample_set; }
     
     void set_input_weights(int size);
@@ -76,7 +76,7 @@ public:
     int log_level(const double& time) { int level; _log_level->getValueAtTime(time, level); return level; }
 
 protected:
-    fx::timer _timer;
+    makehdr::timer _timer;
 
     bool _regen_calib = true;
     int _input_depths[3] = { 256, 1024, 4096 };
@@ -84,7 +84,7 @@ protected:
     std::vector<float> _input_weights;
     std::vector<double> _response;
     std::vector<double> _response_linear;
-    std::vector<fx::point> _sample_points;
+    std::vector<makehdr::point> _sample_points;
     std::unordered_set<int64_t> _sample_set;
 
     OFX::Clip* _dst_clip;

--- a/source/effect.h
+++ b/source/effect.h
@@ -56,21 +56,21 @@ public:
     double* response_linear() { return _response_linear.data(); }
     void set_response_linear_size(int depth) { _response_linear.resize(depth); }
 
-    float exposure(const double& time) { return (float)_exposure->getValueAtTime(time); }
-    float gamma(const double& time) { return (float)_gamma->getValueAtTime(time); }
-    float highlights(const double& time) { return (float)_highlights->getValueAtTime(time); }
+    float exposure(const double& time) { return static_cast<float>(_exposure->getValueAtTime(time)); }
+    float gamma(const double& time) { return static_cast<float>(_gamma->getValueAtTime(time)); }
+    float highlights(const double& time) { return static_cast<float>(_highlights->getValueAtTime(time)); }
     bool calibrate(const double& time) { bool val; _calibrate->getValueAtTime(time, val); return val; }
     bool use_middle_gray(const double& time) { bool val; _use_middle_gray->getValueAtTime(time, val); return val; }
     float middle_gray(const double& time)
     {
         double r, g, b, a;
         _middle_gray->getValueAtTime(time, r, g, b, a);
-        return 0.212671f * (float)r + 0.71516f * (float)g + 0.072169f * (float)b;
+        return 0.212671f * static_cast<float>(r) + 0.71516f * static_cast<float>(g) + 0.072169f * static_cast<float>(b);
     }
     bool show_samples(const double& time) { bool val; _show_samples->getValueAtTime(time, val); return val; }
     int samples(const double& time) { return _samples->getValueAtTime(time); }
     int solver_type(const double& time) { int type; _solver->getValueAtTime(time, type); return type; }
-    float smoothness(const double& time) { return (float)_smoothness->getValueAtTime(time); }
+    float smoothness(const double& time) { return static_cast<float>(_smoothness->getValueAtTime(time)); }
     int input_depth(const double& time) { int depth; _input_depth->getValueAtTime(time, depth); return _input_depths[depth]; }
     int log_level(const double& time) { int level; _log_level->getValueAtTime(time, level); return level; }
 

--- a/source/processor.h
+++ b/source/processor.h
@@ -11,6 +11,12 @@
 #include "resources.h"
 #include "solver.h"
 
+#include "ofxsImageEffect.h"
+#include "ofxsMultiThread.h"
+#include "ofxsProcessing.H"
+
+#include "spdlog/spdlog.h"
+
 
 template <class ptype>
 class Effect;
@@ -260,25 +266,37 @@ public:
         {
             if (_solver_type == 0)
             {
-                threads[c] = std::thread(makehdr::debevec_solver<ptype, OFX::Image>, c,
-                                                        _input_depth,
-                                                        _smoothness,
-                                                        _sources,
-                                                        _effect.sample_points(),
-                                                        _exp_times_log,
-                                                        _effect.input_weights(),
-                                                        _effect.response(_input_depth, c));
+                threads[c] = std::thread([this, c]() {
+                    bool success = makehdr::debevec_solver<ptype, OFX::Image>(c,
+                                                            _input_depth,
+                                                            _smoothness,
+                                                            _sources,
+                                                            _effect.sample_points(),
+                                                            _exp_times_log,
+                                                            _effect.input_weights(),
+                                                            _effect.response(_input_depth, c));
+                    if (!success)
+                        spdlog::error("{}: Debevec calibration failed on {} channel — "
+                                      "check exposure spread and sample count",
+                                      makehdr::label, "RGB"[c]);
+                });
             }
             else if (_solver_type == 1)
             {
-                threads[c] = std::thread(makehdr::robertson_solver<ptype, OFX::Image>, c,
-                                                        _input_depth,
-                                                        (int)_smoothness,
-                                                        _sources,
-                                                        _effect.sample_points(),
-                                                        _exp_times,
-                                                        _effect.input_weights(),
-                                                        _effect.response(_input_depth, c));
+                threads[c] = std::thread([this, c]() {
+                    bool success = makehdr::robertson_solver<ptype, OFX::Image>(c,
+                                                            _input_depth,
+                                                            (int)_smoothness,
+                                                            _sources,
+                                                            _effect.sample_points(),
+                                                            _exp_times,
+                                                            _effect.input_weights(),
+                                                            _effect.response(_input_depth, c));
+                    if (!success)
+                        spdlog::error("{}: Robertson calibration failed on {} channel — "
+                                      "no sample points could be generated",
+                                      makehdr::label, "RGB"[c]);
+                });
             }
         }
 

--- a/source/processor.h
+++ b/source/processor.h
@@ -34,17 +34,17 @@ public:
     {
         if (_sources.empty())
         {
-            spdlog::debug("[{}] sources are empty!", fx::label);
+            spdlog::debug("[{}] sources are empty!", makehdr::label);
             return;
         }
         if (_effect.abort())
         {
-            spdlog::debug("[{}] effect calibrate abort!", fx::label);
+            spdlog::debug("[{}] effect calibrate abort!", makehdr::label);
             return;
         }
         if (!_effect.regen_calib() && !_effect.input_weights().empty())
         {
-            spdlog::debug("[{}] calibrate skipped!", fx::label);
+            spdlog::debug("[{}] calibrate skipped!", makehdr::label);
             return;
         }
 
@@ -119,10 +119,10 @@ public:
                     dst[c] = (ptype)pow(hdr, 1.f / _gamma);
                 }
 
-                if(_show_samples && _effect.sample_set().count(fx::point(x, y).key()))
-                    dst[fx::ch::g] = FLT_MAX;
+                if(_show_samples && _effect.sample_set().count(makehdr::point(x, y).key()))
+                    dst[makehdr::channel::g] = FLT_MAX;
 
-                dst[fx::ch::a] = 1.0f;
+                dst[makehdr::channel::a] = 1.0f;
             }
         }
     }
@@ -149,9 +149,9 @@ public:
 
             if (_use_middle_gray)
             {
-                const float r_lin = std::pow(std::max(0.f, dst[i + fx::ch::r]), _gamma);
-                const float g_lin = std::pow(std::max(0.f, dst[i + fx::ch::g]), _gamma);
-                const float b_lin = std::pow(std::max(0.f, dst[i + fx::ch::b]), _gamma);
+                const float r_lin = std::pow(std::max(0.f, dst[i + makehdr::channel::r]), _gamma);
+                const float g_lin = std::pow(std::max(0.f, dst[i + makehdr::channel::g]), _gamma);
+                const float b_lin = std::pow(std::max(0.f, dst[i + makehdr::channel::b]), _gamma);
                 const float lum_lin = 0.212671f * r_lin + 0.71516f * g_lin + 0.072169f * b_lin;
                 if (lum_lin > 0.f)
                 {
@@ -208,7 +208,7 @@ public:
         }
 
         if(!_effect.abort() && !_sources.empty())
-            spdlog::info("[{}] {} sources merged in {}ms", fx::label, _sources.size(), _timer.get());
+            spdlog::info("[{}] {} sources merged in {}ms", makehdr::label, _sources.size(), _timer.get());
     }
 
     void set_parameters(const double& time)
@@ -247,9 +247,9 @@ public:
             {
                 if (0 <= x && x < _width && 0 <= y && y < _height)
                 {
-                    _effect.sample_points().push_back(fx::point(x, y));
-                    _effect.sample_set().insert(fx::point(x, y).key());
-                    spdlog::debug("{}: Getting sample pos({}, {})", fx::label, x, y);
+                    _effect.sample_points().push_back(makehdr::point(x, y));
+                    _effect.sample_set().insert(makehdr::point(x, y).key());
+                    spdlog::debug("{}: Getting sample pos({}, {})", makehdr::label, x, y);
                 }
             }
         }
@@ -260,7 +260,7 @@ public:
         {
             if (_solver_type == 0)
             {
-                threads[c] = std::thread(debevec_solver<ptype, OFX::Image>, c,
+                threads[c] = std::thread(makehdr::debevec_solver<ptype, OFX::Image>, c,
                                                         _input_depth,
                                                         _smoothness,
                                                         _sources,
@@ -271,7 +271,7 @@ public:
             }
             else if (_solver_type == 1)
             {
-                threads[c] = std::thread(robertson_solver<ptype, OFX::Image>, c,
+                threads[c] = std::thread(makehdr::robertson_solver<ptype, OFX::Image>, c,
                                                         _input_depth,
                                                         (int)_smoothness,
                                                         _sources,
@@ -348,7 +348,7 @@ public:
 
     inline float luminance(float* rgb)
     {
-        return 0.212671f * rgb[fx::ch::r] + 0.71516f * rgb[fx::ch::g] + 0.072169f * rgb[fx::ch::b];
+        return 0.212671f * rgb[makehdr::channel::r] + 0.71516f * rgb[makehdr::channel::g] + 0.072169f * rgb[makehdr::channel::b];
     }
 
     int pixel_size() { return _width * _height * _components; }
@@ -363,7 +363,7 @@ private:
     int _height = 0;
     int _components = 0;
 
-    fx::timer _timer;
+    makehdr::timer _timer;
 
     std::vector<float> _exp_times;
     std::vector<float> _exp_times_log;

--- a/source/processor.h
+++ b/source/processor.h
@@ -75,11 +75,11 @@ public:
                 float fallback_log[3] = { 0.f, 0.f, 0.f };
                 float min_exp_log = FLT_MAX;
 
-                ptype* dst = (ptype*)_dstImg->getPixelAddress(x, y);
+                ptype* dst = static_cast<ptype*>(_dstImg->getPixelAddress(x, y));
 
-                for (int i = 0; i < _sources.size(); ++i)
+                for (int i = 0; i < static_cast<int>(_sources.size()); ++i)
                 {
-                    const ptype* src = (ptype*)_sources[i]->getPixelAddress(x, y);
+                    const ptype* src = static_cast<ptype*>(_sources[i]->getPixelAddress(x, y));
 
                     if (src == nullptr) return;
 
@@ -88,7 +88,7 @@ public:
                     for (int c = 0; c < CMP_MAX; ++c)
                     {
                         const ptype sample = std::min<ptype>(std::max<ptype>(src[c], 0.f), 1.f);
-                        const int bin = (int)(sample * (_input_depth - 1));
+                        const int bin = static_cast<int>(sample * (_input_depth - 1));
                         weight_src += _effect.input_weights()[bin];
                         response_log[c] = lookup_response(bin, c);
                     }
@@ -103,7 +103,7 @@ public:
                         min_exp_log = _exp_times_log[i];
                         for (int c = 0; c < CMP_MAX; ++c)
                         {
-                            const float raw = (float)src[c];
+                            const float raw = static_cast<float>(src[c]);
                             fallback_log[c] = raw > 1.0f
                                 ? std::log(raw) - _exp_times_log[i]
                                 : response_log[c] - _exp_times_log[i];
@@ -122,7 +122,7 @@ public:
                         ? result[c] / weight_sum
                         : fallback_log[c];
                     const float hdr = std::exp(log_hdr);
-                    dst[c] = (ptype)pow(hdr, 1.f / _gamma);
+                    dst[c] = static_cast<ptype>(std::pow(hdr, 1.f / _gamma));
                 }
 
                 if(_show_samples && _effect.sample_set().count(makehdr::point(x, y).key()))
@@ -137,7 +137,7 @@ public:
     {
         if (_sources.empty()) return;
 
-        ptype* dst = (ptype*)_dstImg->getPixelData();
+        ptype* dst = static_cast<ptype*>(_dstImg->getPixelData());
 
         /// Pass 1: scene maximum (always needed for Reinhard) and, when middle gray is enabled, 
         /// log-average of linear luminance for normalisation.
@@ -179,7 +179,7 @@ public:
         float pixel_scale;
         if (_use_middle_gray && _middle_gray > 0.f)
         {
-            const float lum_linear_avg = pixel_count > 0 ? std::exp((float)(log_sum / pixel_count)) : 1.f;
+            const float lum_linear_avg = pixel_count > 0 ? std::exp(static_cast<float>(log_sum / pixel_count)) : 1.f;
             pixel_scale = lum_linear_avg > 0.f
                 ? std::pow(_middle_gray * std::pow(2.f, _exposure) / lum_linear_avg, 1.f / _gamma)
                 : 1.f;
@@ -238,10 +238,10 @@ public:
         _effect.sample_points().clear();
         _effect.sample_set().clear();
 
-        const float aspect = (float)_width / (float)_height;
+        const float aspect = static_cast<float>(_width) / static_cast<float>(_height);
         
         const int actual_samples = (_solver_type == 0) ? _samples : _samples * 100;
-        const int x_points = std::max(1, (int)(sqrt(aspect * actual_samples)));
+        const int x_points = std::max(1, static_cast<int>(std::sqrt(aspect * actual_samples)));
         const int y_points = std::max(1, actual_samples / x_points);
 
         const int step_x = std::max(1, _width / x_points);
@@ -286,7 +286,7 @@ public:
                 threads[c] = std::thread([this, c]() {
                     bool success = makehdr::robertson_solver<ptype, OFX::Image>(c,
                                                             _input_depth,
-                                                            (int)_smoothness,
+                                                            static_cast<int>(_smoothness),
                                                             _sources,
                                                             _effect.sample_points(),
                                                             _exp_times,
@@ -360,8 +360,8 @@ public:
     inline float lookup_response(int bin, int channel) const
     {
         return _calibrate
-            ? (float)_effect.response(_input_depth, channel)[bin]
-            : (float)_effect.response_linear()[bin];
+            ? static_cast<float>(_effect.response(_input_depth, channel)[bin])
+            : static_cast<float>(_effect.response_linear()[bin]);
     }
 
     inline float luminance(float* rgb)

--- a/source/resources.h
+++ b/source/resources.h
@@ -33,7 +33,7 @@
 #define SRC_MAX 16
 
 
-namespace fx
+namespace makehdr
 {
     const std::string label = "MakeHDR";
     const std::string version = std::to_string(VERSION_MAJOR) + "." + 
@@ -43,7 +43,7 @@ namespace fx
     const std::string description = label + " v" + version + 
         " developed by Vahan Sosoyan";
 
-    enum ch
+    enum channel
     {
         r, g, b, a
     };

--- a/source/resources.h
+++ b/source/resources.h
@@ -17,13 +17,7 @@
 #include <unordered_set>
 #include <cstdint>
 
-#include "spdlog/spdlog.h"
-
 #include "armadillo"
-
-#include "ofxsImageEffect.h"
-#include "ofxsMultiThread.h"
-#include "ofxsProcessing.H"
 
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 4

--- a/source/resources.h
+++ b/source/resources.h
@@ -53,7 +53,7 @@ namespace makehdr
         int x;
         int y;
 
-        int64_t key() const { return (int64_t)x << 32 | (uint32_t)y; }
+        int64_t key() const { return static_cast<int64_t>(x) << 32 | static_cast<uint32_t>(y); }
     };
 
     class timer

--- a/source/solver.h
+++ b/source/solver.h
@@ -22,12 +22,12 @@ inline int extract_pixel_index(const std::shared_ptr<ImageType>& source,
             const int channel, 
             const int input_depth)
 {
-    ptype* sample = (ptype*)source->getPixelAddress(point.x, point.y);
+    ptype* sample = static_cast<ptype*>(source->getPixelAddress(point.x, point.y));
     float sample_flt = sample == nullptr ? 0 : sample[channel];
     sample_flt = std::min<float>(sample_flt, 1.f);
     sample_flt = std::max<float>(sample_flt, 0.f);
 
-    return (int)(sample_flt * (input_depth - 1));
+    return static_cast<int>(sample_flt * (input_depth - 1));
 }
 
 /// Implements Paul E. Debevec & Jitendra Malik, 1997
@@ -43,8 +43,8 @@ bool debevec_solver(const int channel,
             double* response)
 {
 
-    const int sources_size = (int)sources.size();
-    const int samples_size = (int)points.size();
+    const int sources_size = static_cast<int>(sources.size());
+    const int samples_size = static_cast<int>(points.size());
 
     const int m = samples_size * sources_size + (input_depth - 2) + 1;
     const int n = input_depth + samples_size;
@@ -123,12 +123,12 @@ bool robertson_solver(const int channel,
                       double* response)
 {
 
-    const int sources_size = (int)sources.size();
-    const int samples_size = (int)points.size();
+    const int sources_size = static_cast<int>(sources.size());
+    const int samples_size = static_cast<int>(points.size());
 
     std::vector<double> I(input_depth);
     for (int i = 0; i < input_depth; ++i)
-        I[i] = (double)i / (double)(input_depth - 1);
+        I[i] = static_cast<double>(i) / static_cast<double>(input_depth - 1);
 
     std::vector<double> E(samples_size, 0.0);
 
@@ -195,12 +195,12 @@ bool robertson_solver(const int channel,
         for (int m = 0; m < input_depth; ++m) {
             if (I[m] >= 0.0) {
                 if (last_valid == -1) {
-                    for (int k = 0; k < m; ++k) I[k] = I[m] * ((double)k / std::max(1, m)); 
+                    for (int k = 0; k < m; ++k) I[k] = I[m] * (static_cast<double>(k) / std::max(1, m));
                 } else if (m - last_valid > 1) {
                     double v0 = std::log(std::max(1e-12, I[last_valid]));
                     double v1 = std::log(std::max(1e-12, I[m]));
                     for (int k = last_valid + 1; k < m; ++k) {
-                        double t = (double)(k - last_valid) / (m - last_valid);
+                        double t = static_cast<double>(k - last_valid) / (m - last_valid);
                         I[k] = std::exp(v0 + t * (v1 - v0));
                     }
                 }

--- a/source/solver.h
+++ b/source/solver.h
@@ -33,7 +33,7 @@ inline int extract_pixel_index(const std::shared_ptr<ImageType>& source,
 /// Implements Paul E. Debevec & Jitendra Malik, 1997
 /// "Recovering High Dynamic Range Radiance Maps from Photographs"
 template<typename ptype, typename ImageType>
-void debevec_solver(const int channel,
+bool debevec_solver(const int channel,
             const int input_depth,
             const float smoothness,
             const std::vector<std::shared_ptr<ImageType>>& sources,
@@ -106,14 +106,14 @@ void debevec_solver(const int channel,
         for (int i = 0; i < input_depth; ++i)
             response[i] = s[i];
     }
-    else
-        spdlog::error("{}: Solver has failed for channel {}!", makehdr::label , channel);
+
+    return success;
 }
 
 /// Implements Mark A. Robertson et al., 1999
 /// "Dynamic Range Improvement Through Multiple Exposures"
 template<typename ptype, typename ImageType>
-void robertson_solver(const int channel,
+bool robertson_solver(const int channel,
                       const int input_depth,
                       const int iterations,
                       const std::vector<std::shared_ptr<ImageType>>& sources,
@@ -142,6 +142,7 @@ void robertson_solver(const int channel,
         }
     }
 
+    int last_valid = -1;
     for (int iter = 0; iter < iterations; ++iter)
     {
         /// 1. Estimate irradiance E for each sample
@@ -190,7 +191,7 @@ void robertson_solver(const int channel,
         }
 
         /// 3. Interpolate unobserved values in the Log-Domain
-        int last_valid = -1;
+        last_valid = -1;
         for (int m = 0; m < input_depth; ++m) {
             if (I[m] >= 0.0) {
                 if (last_valid == -1) {
@@ -212,6 +213,9 @@ void robertson_solver(const int channel,
             }
         }
 
+        /// Degenerate: no bin observed — skip monotonicity, normalisation and remaining iterations
+        if (last_valid == -1) break;
+
         /// 4. Enforce strict monotonicity (crucial to prevent color channel inversions)
         for (int m = 1; m < input_depth; ++m) {
             if (I[m] < I[m - 1]) I[m] = I[m - 1];
@@ -226,14 +230,22 @@ void robertson_solver(const int channel,
         }
     }
 
+    /// Degenerate output: no bin was ever observed (e.g. all-black or fully-clipped inputs).
+    const bool success = (last_valid != -1);
+
     /// 6. Output Logarithmic Response exactly like Debevec so processor logic stays identical
-    for (int m = 0; m < input_depth; ++m)
+    if (success)
     {
-        if (I[m] <= 0.0)
-            response[m] = std::log(1e-6); 
-        else
-            response[m] = std::log(I[m]);
+        for (int m = 0; m < input_depth; ++m)
+        {
+            if (I[m] <= 0.0)
+                response[m] = std::log(1e-6); 
+            else
+                response[m] = std::log(I[m]);
+        }
     }
+
+    return success;
 }
 
 } // namespace makehdr

--- a/source/solver.h
+++ b/source/solver.h
@@ -11,11 +11,14 @@
 #include "resources.h"
 
 
+namespace makehdr
+{
+
 /// Extracts the pixel value for a given point and channel, 
 /// returning an integer in the range [0, input_depth-1].
 template<typename ptype, typename ImageType>
 inline int extract_pixel_index(const std::shared_ptr<ImageType>& source, 
-            const fx::point& point, 
+            const makehdr::point& point, 
             const int channel, 
             const int input_depth)
 {
@@ -34,7 +37,7 @@ void debevec_solver(const int channel,
             const int input_depth,
             const float smoothness,
             const std::vector<std::shared_ptr<ImageType>>& sources,
-            const std::vector<fx::point>& points,
+            const std::vector<makehdr::point>& points,
             const std::vector<float>& exp_times_log,
             const std::vector<float>& input_weights,
             double* response)
@@ -104,7 +107,7 @@ void debevec_solver(const int channel,
             response[i] = s[i];
     }
     else
-        spdlog::error("{}: Solver has failed for channel {}!", fx::label , channel);
+        spdlog::error("{}: Solver has failed for channel {}!", makehdr::label , channel);
 }
 
 /// Implements Mark A. Robertson et al., 1999
@@ -114,7 +117,7 @@ void robertson_solver(const int channel,
                       const int input_depth,
                       const int iterations,
                       const std::vector<std::shared_ptr<ImageType>>& sources,
-                      const std::vector<fx::point>& points,
+                      const std::vector<makehdr::point>& points,
                       const std::vector<float>& exp_times,
                       const std::vector<float>& input_weights,
                       double* response)
@@ -232,5 +235,7 @@ void robertson_solver(const int channel,
             response[m] = std::log(I[m]);
     }
 }
+
+} // namespace makehdr
 
 #endif


### PR DESCRIPTION
Hi @sosoyan,

had some time for a mechanical refactoring to improve the codebase:

* Modernized casts (Bulk of the PR): Replaced C-style casts with `static_cast`.
* Safer Namespace: Renamed `fx` to `makehdr` across all source files to avoid potential symbol collisions.
* Untangled Headers: Moved `ofx` and `spdlog` includes out of `resources.h` and into the specific files that need them to reduce unnecessary build coupling.
* Solvers: Solvers now return a `bool` to short-circuit degenerate cases (like all-black/fully-clipped inputs) rather than writing a garbage response curve.
* Thread Dispatch: Calibration threads now capture solver return values, logging a descriptive, per-channel error if something goes wrong.

What do you think? If something else comes into your mind, just let me know.

Cheers,
Christian