### PR TITLE
Decouple merge and tone-mapping

### DIFF
--- a/source/effect.cpp
+++ b/source/effect.cpp
@@ -157,13 +157,8 @@ void Effect<ptype>::set_log_level(int level)
 template<class ptype>
 void Effect<ptype>::set_input_weights(int size)
 {
-    if (size != _input_weights.size())
-    {
-        _input_weights.resize(size);
-
-        for (int i = 0; i < size; ++i)
-            _input_weights[i] = static_cast<float>(std::min(i, size - 1 - i));
-    }
+    if (size != static_cast<int>(_input_weights.size()))
+        _input_weights = makehdr::build_weights(size);
 }
 
 void EffectPluginFactory::describe(OFX::ImageEffectDescriptor& desc)

--- a/source/merge.h
+++ b/source/merge.h
@@ -1,0 +1,388 @@
+//
+//  merge.h
+//  MakeHDR
+//
+//  Merge and tone-mapping utilities.
+//
+
+#ifndef merge_h
+#define merge_h
+
+#include <algorithm>
+#include <array>
+#include <cfloat>
+#include <cmath>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "resources.h"
+#include "solver.h"
+
+
+namespace makehdr {
+
+struct merge_params {
+    // Calibration
+    int   depth             = 256;
+    int   solver_type       = 0;
+    float smoothness        = 10.f;  // Debevec: lambda weight
+    int   robertson_iters   = 10;    // Robertson: iteration count
+    int   samples           = 200;
+    // Merge
+    bool  calibrate         = true;
+    float gamma             = 1.f;
+    int   channels          = 4;
+    // Post-process
+    float exposure          = 0.f;
+    float highlights        = 1.f;
+    bool  use_middle_gray   = false;
+    float middle_gray       = 0.18f;
+};
+
+inline std::vector<float> build_weights(int depth)
+{
+    std::vector<float> w(depth);
+    for (int i = 0; i < depth; ++i)
+        w[i] = static_cast<float>(std::min(i, depth - 1 - i));
+    return w;
+}
+
+inline std::vector<point> build_sample_points(int width, int height, int samples)
+{
+    const float aspect = static_cast<float>(width) / static_cast<float>(height);
+    const int x_pts    = std::max(1, static_cast<int>(std::sqrt(aspect * samples)));
+    const int y_pts    = std::max(1, samples / x_pts);
+    const int step_x   = std::max(1, width  / x_pts);
+    const int step_y   = std::max(1, height / y_pts);
+
+    std::vector<point> pts;
+    pts.reserve(x_pts * y_pts);
+    for (int i = 0, x = step_x / 2; i < x_pts; ++i, x += step_x)
+        for (int j = 0, y = step_y / 2; j < y_pts; ++j, y += step_y)
+            if (x < width && y < height)
+                pts.push_back(point(x, y));
+    return pts;
+}
+
+inline void build_linear_response(int depth, double* out)
+{
+    for (int i = 0; i < depth; ++i)
+        out[i] = std::log(i * (1.f / depth));
+    out[0] = out[1];
+}
+
+template<typename PixelType, typename ImageType>
+std::array<bool, CMP_MAX> run_debevec_calibration(
+    const std::vector<std::shared_ptr<ImageType>>& sources,
+    const std::vector<float>& exp_times_log,
+    const merge_params& p,
+    const std::vector<float>& weights,
+    const std::vector<point>& sample_points,
+    double* response)
+{
+    std::array<bool, CMP_MAX> results = {};
+    std::thread threads[CMP_MAX];
+
+    for (int c = 0; c < CMP_MAX; ++c)
+    {
+        threads[c] = std::thread([&, c, response]()
+        {
+            results[c] = debevec_solver<PixelType, ImageType>(
+                c, p.depth, p.smoothness,
+                sources, sample_points,
+                exp_times_log, weights,
+                response + p.depth * c);
+        });
+    }
+
+    for (int c = 0; c < CMP_MAX; ++c)
+        threads[c].join();
+
+    return results;
+}
+
+inline void average_robertson_curves(double* response, int depth)
+{
+    /// Robertson runs per-channel independently, producing divergent curve shapes
+    /// on sparse linear data. Average them into one shared curve to eliminate tints,
+    /// then smooth to remove kinks from sparsely-sampled bins near highlights.
+    /// 3 passes of box-filter smoothing approximates a Gaussian kernel,
+    /// handling broader plateau-type banding from sparsely-sampled highlight bins.
+    for (int m = 0; m < depth; ++m)
+    {
+        double avg = 0.0;
+        for (int c = 0; c < CMP_MAX; ++c)
+            avg += response[depth * c + m];
+        avg /= CMP_MAX;
+        for (int c = 0; c < CMP_MAX; ++c)
+            response[depth * c + m] = avg;
+    }
+
+    const int radius = 4;
+    const int passes = 3;
+    std::vector<double> smoothed(depth);
+    for (int pass = 0; pass < passes; ++pass)
+    {
+        const double* curve = response;
+        for (int m = 0; m < depth; ++m)
+        {
+            double sum = 0.0;
+            int count  = 0;
+            for (int k = std::max(0, m - radius); k <= std::min(depth - 1, m + radius); ++k)
+            {
+                sum += curve[k];
+                ++count;
+            }
+            smoothed[m] = sum / count;
+        }
+        for (int m = 0; m < depth; ++m)
+            for (int c = 0; c < CMP_MAX; ++c)
+                response[depth * c + m] = smoothed[m];
+    }
+}
+
+template<typename PixelType, typename ImageType>
+std::array<bool, CMP_MAX> run_robertson_calibration(
+    const std::vector<std::shared_ptr<ImageType>>& sources,
+    const std::vector<float>& exp_times,
+    const merge_params& p,
+    const std::vector<float>& weights,
+    const std::vector<point>& sample_points,
+    double* response)
+{
+    std::array<bool, CMP_MAX> results = {};
+    std::thread threads[CMP_MAX];
+
+    for (int c = 0; c < CMP_MAX; ++c)
+    {
+        threads[c] = std::thread([&, c, response]()
+        {
+            results[c] = robertson_solver<PixelType, ImageType>(
+                c, p.depth, p.robertson_iters,
+                sources, sample_points,
+                exp_times, weights,
+                response + p.depth * c);
+        });
+    }
+
+    for (int c = 0; c < CMP_MAX; ++c)
+        threads[c].join();
+
+    average_robertson_curves(response, p.depth);
+
+    return results;
+}
+
+inline float luminance(const float* rgb)
+{
+    return 0.212671f * rgb[0] + 0.71516f * rgb[1] + 0.072169f * rgb[2];
+}
+
+/// Bundles all inputs needed to merge a single pixel — source images, exposure times,
+/// weight table, response curves and parameters. Constructed once per region in
+/// merge_hdr_region and forwarded by const-ref to every merge_pixel call.
+template<typename SrcImageType>
+struct merge_context {
+    const std::vector<std::shared_ptr<SrcImageType>>& sources;
+    const std::vector<float>& exp_times_log;
+    const std::vector<float>& weights;
+    const double* response;
+    const double* response_linear;
+    const merge_params& p;
+};
+
+/// Accumulates all source contributions for a single pixel and writes the HDR result.
+/// Returns false if a null source is encountered, signalling the caller to halt region processing.
+template<typename PixelType, typename SrcImageType>
+bool merge_pixel(int x, int y, PixelType* dp, const merge_context<SrcImageType>& ctx)
+{
+    float weight_sum            = 0.f;
+    float response_log[CMP_MAX] = {};
+    float result[CMP_MAX]       = {};
+    float fallback_log[CMP_MAX] = {};
+    float min_exp_log           = FLT_MAX;
+
+    for (int i = 0; i < static_cast<int>(ctx.sources.size()); ++i)
+    {
+        const PixelType* src = static_cast<const PixelType*>(ctx.sources[i]->getPixelAddress(x, y));
+        if (!src) return false;
+
+        float weight_src = 0.f;
+        const float exp_log = ctx.exp_times_log[i];
+        for (int c = 0; c < CMP_MAX; ++c)
+        {
+            const float s = std::min(std::max(static_cast<float>(src[c]), 0.f), 1.f);
+            const int bin = static_cast<int>(s * (ctx.p.depth - 1));
+            weight_src += ctx.weights[bin];
+            response_log[c] = ctx.p.calibrate
+                ? static_cast<float>(ctx.response[ctx.p.depth * c + bin])
+                : static_cast<float>(ctx.response_linear[bin]);
+        }
+        weight_src /= CMP_MAX;
+
+        /// Track the darkest source as fallback for fully-clipped pixels.
+        /// Use raw unclamped value when > 1.0 (genuine HDR in linear float),
+        /// otherwise use the response curve at bin 255 (clipped at camera max).
+        if (exp_log < min_exp_log)
+        {
+            min_exp_log = exp_log;
+            for (int c = 0; c < CMP_MAX; ++c)
+            {
+                const float raw = static_cast<float>(src[c]);
+                fallback_log[c] = raw > 1.f
+                    ? std::log(raw) - exp_log
+                    : response_log[c] - exp_log;
+            }
+        }
+
+        for (int c = 0; c < CMP_MAX; ++c)
+            result[c] += weight_src * (response_log[c] - exp_log);
+
+        weight_sum += weight_src;
+    }
+
+    for (int c = 0; c < CMP_MAX; ++c)
+    {
+        const float log_hdr = weight_sum > 0.f
+            ? result[c] / weight_sum
+            : fallback_log[c];
+        dp[c] = static_cast<PixelType>(std::pow(std::exp(log_hdr), 1.f / ctx.p.gamma));
+    }
+
+    if (ctx.p.channels > 3)
+        dp[static_cast<int>(channel::a)] = 1.0f;
+
+    return true;
+}
+
+/// Merges all source images into dst over the rectangle [x1,y1)–[x2,y2).
+/// Checks abort_fn once per scanline and returns early if it fires.
+template<typename PixelType, typename SrcImageType, typename DstImageType, typename AbortFn>
+void merge_hdr_region(
+    const std::vector<std::shared_ptr<SrcImageType>>& sources,
+    const std::vector<float>& exp_times_log,
+    const std::vector<float>& weights,
+    const double* response,
+    const double* response_linear,
+    DstImageType* dst,
+    int x1, int y1, int x2, int y2,
+    const merge_params& p,
+    AbortFn&& abort_fn)
+{
+    const merge_context<SrcImageType> ctx { sources, exp_times_log, weights, response, response_linear, p };
+
+    for (int y = y1; y < y2; ++y)
+    {
+        if (abort_fn()) return;
+
+        for (int x = x1; x < x2; ++x)
+        {
+            PixelType* dp = static_cast<PixelType*>(dst->getPixelAddress(x, y));
+            if (!merge_pixel<PixelType>(x, y, dp, ctx))
+                return;
+        }
+    }
+}
+
+template<typename PixelType>
+void post_process_buffer(PixelType* dst, int buf_size, const merge_params& p)
+{
+    float  lum_max  = 0.f;
+    double log_sum  = 0.0;
+    int    px_count = 0;
+
+    /// Pass 1: scene maximum (always needed for Reinhard) and, when middle gray is enabled,
+    /// log-average of linear luminance for normalisation.
+    ///   L_avg = exp(mean(log(ε + L_linear_i))) [Reinhard 2002, eq. 1]
+    ///
+    /// dst currently holds hdr^(1/gamma) (gamma-encoded, no exposure).
+    /// For the geometric mean, linear luminance is recovered per channel before weighting:
+    ///   lum_linear = 0.212671*R^gamma + 0.71516*G^gamma + 0.072169*B^gamma
+    for (int i = 0; i < buf_size; i += p.channels)
+    {
+        const float px[3] = {
+            static_cast<float>(dst[i + 0]),
+            static_cast<float>(dst[i + 1]),
+            static_cast<float>(dst[i + 2])
+        };
+
+        const float lum = luminance(px);
+        lum_max = std::max(lum_max, lum);
+
+        if (p.use_middle_gray)
+        {
+            const float r_lin = std::pow(std::max(0.f, px[0]), p.gamma);
+            const float g_lin = std::pow(std::max(0.f, px[1]), p.gamma);
+            const float b_lin = std::pow(std::max(0.f, px[2]), p.gamma);
+            const float l_lin = 0.212671f * r_lin + 0.71516f * g_lin + 0.072169f * b_lin;
+            if (l_lin > 0.f)
+            {
+                log_sum += std::log(1e-6f + l_lin);
+                ++px_count;
+            }
+        }
+    }
+
+    /// Pre-scaling: exposure only, or combined middle-gray normalisation + exposure.
+    ///
+    /// When middle gray is OFF (backwards-compatible mode):
+    ///   pixel_scale = pow(2^exposure, 1/gamma)
+    ///   result = pow(hdr * 2^exposure, 1/gamma)  -- original formula.
+    ///
+    /// When middle gray is enabled:
+    ///   pixel_scale = pow(middle_gray * 2^exposure / lum_linear_avg, 1/gamma)
+    ///   result = pow(hdr * middle_gray / lum_linear_avg * 2^exposure, 1/gamma)
+    float pixel_scale;
+    if (p.use_middle_gray && p.middle_gray > 0.f)
+    {
+        const float l_avg = px_count > 0 ? std::exp(static_cast<float>(log_sum / px_count)) : 1.f;
+        pixel_scale = l_avg > 0.f
+            ? std::pow(p.middle_gray * std::pow(2.f, p.exposure) / l_avg, 1.f / p.gamma)
+            : 1.f;
+    }
+    else
+    {
+        pixel_scale = std::pow(std::pow(2.f, p.exposure), 1.f / p.gamma);
+    }
+
+    const float scaled_max  = lum_max * pixel_scale;
+    const float log_lum_max = std::log10(1.f + scaled_max);
+
+    /// Pass 2: Reinhard global tone mapping.
+    /// highlights blends between fully tone-mapped (0) and linear (1).
+    ///   L_d = log10(1 + L_scaled) / log10(1 + L_max_scaled)  [display luminance]
+    ///   C_d = L_d * C / L  [per-channel, preserves hue]
+    for (int i = 0; i < buf_size; i += p.channels)
+    {
+        float px[3] = {
+            static_cast<float>(dst[i + 0]) * pixel_scale,
+            static_cast<float>(dst[i + 1]) * pixel_scale,
+            static_cast<float>(dst[i + 2]) * pixel_scale
+        };
+
+        const float lum = luminance(px);
+        if (lum == 0.f || scaled_max == 0.f)
+        {
+            dst[i + 0] = static_cast<PixelType>(px[0]);
+            dst[i + 1] = static_cast<PixelType>(px[1]);
+            dst[i + 2] = static_cast<PixelType>(px[2]);
+            continue;
+        }
+
+        const float lum_dif = std::log10(1.f + lum) / log_lum_max;
+        for (int c = 0; c < CMP_MAX; ++c)
+        {
+            const float tone = lum_dif * px[c] / lum;
+            px[c] = tone + (px[c] - tone) * p.highlights;
+        }
+
+        dst[i + 0] = static_cast<PixelType>(px[0]);
+        dst[i + 1] = static_cast<PixelType>(px[1]);
+        dst[i + 2] = static_cast<PixelType>(px[2]);
+    }
+}
+
+} // namespace makehdr
+
+#endif  // merge_h

--- a/source/processor.h
+++ b/source/processor.h
@@ -9,7 +9,7 @@
 #define processor_h
 
 #include "resources.h"
-#include "solver.h"
+#include "merge.h"
 
 #include "ofxsImageEffect.h"
 #include "ofxsMultiThread.h"
@@ -27,9 +27,9 @@ class Processor : public OFX::ImageProcessor
 public:
     Processor(Effect<ptype>& effect,
               const unsigned int components) : OFX::ImageProcessor(effect),
-                                               _effect(effect),
-                                               _components(components)
+                                               _effect(effect)
     {
+        _params.channels = static_cast<int>(components);
     }
 
     ~Processor()
@@ -54,352 +54,135 @@ public:
             return;
         }
 
-        _effect.set_input_weights(_input_depth);
-        _calibrate ? calibrate() : calibrate_linear();
+        _effect.set_input_weights(_params.depth);
+        _params.calibrate ? calibrate() : calibrate_linear();
     }
 
     virtual void multiThreadProcessImages(OfxRectI proc_window)
     {
         if (_sources.empty()) return;
 
+        makehdr::merge_hdr_region<ptype, OFX::Image, OFX::Image>(
+            _sources, _exp_times_log,
+            _effect.input_weights(),
+            _effect.response(_params.depth, 0),
+            _effect.response_linear(),
+            _dstImg,
+            proc_window.x1, proc_window.y1, proc_window.x2, proc_window.y2,
+            _params,
+            [this]{ return _effect.abort(); });
 
-        for (int y = proc_window.y1; y < proc_window.y2; ++y)
+        if (_show_samples)
         {
-            if (_effect.abort()) return;
-
-            for (int x = proc_window.x1; x < proc_window.x2; ++x)
+            for (const makehdr::point& p : _effect.sample_points())
             {
-                float weight_sum = 0.f;
-                float response_log[3] = { 0.f, 0.f, 0.f };
-                float result[3] = { 0.f, 0.f, 0.f };
-                float fallback_log[3] = { 0.f, 0.f, 0.f };
-                float min_exp_log = FLT_MAX;
-
-                ptype* dst = static_cast<ptype*>(_dstImg->getPixelAddress(x, y));
-
-                for (int i = 0; i < static_cast<int>(_sources.size()); ++i)
-                {
-                    const ptype* src = static_cast<ptype*>(_sources[i]->getPixelAddress(x, y));
-
-                    if (src == nullptr) return;
-
-                    float weight_src = 0.f;
-
-                    for (int c = 0; c < CMP_MAX; ++c)
-                    {
-                        const ptype sample = std::min<ptype>(std::max<ptype>(src[c], 0.f), 1.f);
-                        const int bin = static_cast<int>(sample * (_input_depth - 1));
-                        weight_src += _effect.input_weights()[bin];
-                        response_log[c] = lookup_response(bin, c);
-                    }
-
-                    weight_src /= CMP_MAX;
-
-                    /// Track the darkest source as fallback for fully-clipped pixels.
-                    /// Use raw unclamped value when > 1.0 (genuine HDR in linear float),
-                    /// otherwise use the response curve at bin 255 (clipped at camera max).
-                    if (_exp_times_log[i] < min_exp_log)
-                    {
-                        min_exp_log = _exp_times_log[i];
-                        for (int c = 0; c < CMP_MAX; ++c)
-                        {
-                            const float raw = static_cast<float>(src[c]);
-                            fallback_log[c] = raw > 1.0f
-                                ? std::log(raw) - _exp_times_log[i]
-                                : response_log[c] - _exp_times_log[i];
-                        }
-                    }
-
-                    for (int c = 0; c < CMP_MAX; ++c)
-                        result[c] += weight_src * (response_log[c] - _exp_times_log[i]);
-
-                    weight_sum += weight_src;
-                }
-
-                for (int c = 0; c < CMP_MAX; ++c)
-                {
-                    const float log_hdr = weight_sum > 0.f
-                        ? result[c] / weight_sum
-                        : fallback_log[c];
-                    const float hdr = std::exp(log_hdr);
-                    dst[c] = static_cast<ptype>(std::pow(hdr, 1.f / _gamma));
-                }
-
-                if(_show_samples && _effect.sample_set().count(makehdr::point(x, y).key()))
-                    dst[makehdr::channel::g] = FLT_MAX;
-
-                dst[makehdr::channel::a] = 1.0f;
+                ptype* dp = static_cast<ptype*>(_dstImg->getPixelAddress(p.x, p.y));
+                if (dp)
+                    dp[static_cast<int>(makehdr::channel::g)] = FLT_MAX;
             }
         }
     }
 
-    virtual void postProcess() 
+    virtual void postProcess()
     {
         if (_sources.empty()) return;
 
         ptype* dst = static_cast<ptype*>(_dstImg->getPixelData());
 
-        /// Pass 1: scene maximum (always needed for Reinhard) and, when middle gray is enabled, 
-        /// log-average of linear luminance for normalisation.
-        ///   L_avg = exp(mean(log(ε + L_linear_i))) [Reinhard 2002, eq. 1]
-        ///
-        /// dst currently holds hdr^(1/gamma) (gamma-encoded, no exposure).
-        /// For the geometric mean, linear luminance is recovered per channel before weighting:
-        ///   lum_linear = 0.212671*R^gamma + 0.71516*G^gamma + 0.072169*B^gamma
-        double log_sum = 0.0;
-        int pixel_count = 0;
-        for (int i = 0; i < pixel_size(); i += _components)
-        {
-            const float lum = luminance(dst + i);
-            _luminance_max = std::max(lum, _luminance_max);
+        makehdr::post_process_buffer<ptype>(
+            dst, pixel_size(), _params);
 
-            if (_use_middle_gray)
-            {
-                const float r_lin = std::pow(std::max(0.f, dst[i + makehdr::channel::r]), _gamma);
-                const float g_lin = std::pow(std::max(0.f, dst[i + makehdr::channel::g]), _gamma);
-                const float b_lin = std::pow(std::max(0.f, dst[i + makehdr::channel::b]), _gamma);
-                const float lum_lin = 0.212671f * r_lin + 0.71516f * g_lin + 0.072169f * b_lin;
-                if (lum_lin > 0.f)
-                {
-                    log_sum += std::log(1e-6f + lum_lin);
-                    ++pixel_count;
-                }
-            }
-        }
-
-        /// Pre-scaling: exposure only, or combined middle-gray normalisation + exposure.
-        ///
-        /// When middle gray is OFF (backwards-compatible mode):
-        ///   pixel_scale = pow(2^exposure, 1/gamma)
-        ///   result = pow(hdr * 2^exposure, 1/gamma)  -- original formula.
-        ///
-        /// When middle gray is enabled:
-        ///   pixel_scale = pow(middle_gray * 2^exposure / lum_linear_avg, 1/gamma)
-        ///   result = pow(hdr * middle_gray / lum_linear_avg * 2^exposure, 1/gamma)
-        float pixel_scale;
-        if (_use_middle_gray && _middle_gray > 0.f)
-        {
-            const float lum_linear_avg = pixel_count > 0 ? std::exp(static_cast<float>(log_sum / pixel_count)) : 1.f;
-            pixel_scale = lum_linear_avg > 0.f
-                ? std::pow(_middle_gray * std::pow(2.f, _exposure) / lum_linear_avg, 1.f / _gamma)
-                : 1.f;
-        }
-        else
-        {
-            pixel_scale = std::pow(std::pow(2.f, _exposure), 1.f / _gamma);
-        }
-        const float scaled_lum_max = _luminance_max * pixel_scale;
-        const float log_lum_max = std::log10(1.f + scaled_lum_max);
-
-        /// Pass 2: Reinhard global tone mapping
-        /// highlights blends between fully tone-mapped (0) and linear (1)
-        ///   L_d = log10(1 + L_scaled) / log10(1 + L_max_scaled)  [display luminance]
-        ///   C_d = L_d * C / L  [per-channel, preserves hue]
-        for (int i = 0; i < pixel_size(); i += _components)
-        {
-            for (int c = 0; c < CMP_MAX; ++c)
-                dst[i + c] *= pixel_scale;
-
-            const float lum = luminance(dst + i);
-            if (lum == 0.f || scaled_lum_max == 0.f)
-                continue;
-
-            const float lum_dif = std::log10(1.f + lum) / log_lum_max;
-
-            for (int c = 0; c < CMP_MAX; ++c)
-            {
-                const float tone = lum_dif * dst[i + c] / lum;
-                dst[i + c] = tone + (dst[i + c] - tone) * _highlights;
-            }
-        }
-
-        if(!_effect.abort() && !_sources.empty())
+        if (!_effect.abort())
             spdlog::info("[{}] {} sources merged in {}ms", makehdr::label, _sources.size(), _timer.get());
     }
 
     void set_parameters(const double& time)
     {
-        _exposure = _effect.exposure(time);
-        _gamma = _effect.gamma(time);
-        _highlights = _effect.highlights(time);
-        _calibrate = _effect.calibrate(time);
-        _show_samples = _effect.show_samples(time);
-        _samples = _effect.samples(time);
-        _solver_type = _effect.solver_type(time);
-        _smoothness = _effect.smoothness(time);
-        _input_depth = _effect.input_depth(time);
-        _use_middle_gray = _effect.use_middle_gray(time);
-        _middle_gray = _effect.middle_gray(time);
+        _params.exposure        = _effect.exposure(time);
+        _params.gamma           = _effect.gamma(time);
+        _params.highlights      = _effect.highlights(time);
+        _params.calibrate       = _effect.calibrate(time);
+        _params.samples         = _effect.samples(time);
+        _params.solver_type     = _effect.solver_type(time);
+        _params.smoothness      = _effect.smoothness(time);
+        _params.robertson_iters = static_cast<int>(_params.smoothness);
+        _params.depth           = _effect.input_depth(time);
+        _params.use_middle_gray = _effect.use_middle_gray(time);
+        _params.middle_gray     = _effect.middle_gray(time);
+        _show_samples           = _effect.show_samples(time);
     }
 
     void calibrate()
-    {   
+    {
         _effect.set_regen_calib(false);
-        _effect.sample_points().clear();
-        _effect.sample_set().clear();
 
-        const float aspect = static_cast<float>(_width) / static_cast<float>(_height);
-        
-        const int actual_samples = (_solver_type == 0) ? _samples : _samples * 100;
-        const int x_points = std::max(1, static_cast<int>(std::sqrt(aspect * actual_samples)));
-        const int y_points = std::max(1, actual_samples / x_points);
-
-        const int step_x = std::max(1, _width / x_points);
-        const int step_y = std::max(1, _height / y_points);
-
-        for (int i = 0, x = step_x / 2; i < x_points; i++, x += step_x)
+        if (_params.solver_type == 0)
         {
-            for (int j = 0, y = step_y / 2; j < y_points; j++, y += step_y)
-            {
-                if (0 <= x && x < _width && 0 <= y && y < _height)
+            _effect.sample_points() = makehdr::build_sample_points(_width, _height, _params.samples);
+            const std::array<bool, CMP_MAX> results = makehdr::run_debevec_calibration<ptype, OFX::Image>(
+                _sources, _exp_times_log, _params,
+                _effect.input_weights(), _effect.sample_points(),
+                _effect.response(_params.depth, 0));
+            for (int c = 0; c < CMP_MAX; ++c)
+                if (!results[c])
                 {
-                    _effect.sample_points().push_back(makehdr::point(x, y));
-                    _effect.sample_set().insert(makehdr::point(x, y).key());
-                    spdlog::debug("{}: Getting sample pos({}, {})", makehdr::label, x, y);
+                    spdlog::error("{}: Debevec calibration failed on {} channel — "
+                                  "check exposure spread and sample count",
+                                  makehdr::label, "RGB"[c]);
+                    break;
                 }
-            }
         }
-        
-        std::thread threads[CMP_MAX];
-
-        for (int c = 0; c < CMP_MAX; ++c)
+        else if (_params.solver_type == 1)
         {
-            if (_solver_type == 0)
-            {
-                threads[c] = std::thread([this, c]() {
-                    bool success = makehdr::debevec_solver<ptype, OFX::Image>(c,
-                                                            _input_depth,
-                                                            _smoothness,
-                                                            _sources,
-                                                            _effect.sample_points(),
-                                                            _exp_times_log,
-                                                            _effect.input_weights(),
-                                                            _effect.response(_input_depth, c));
-                    if (!success)
-                        spdlog::error("{}: Debevec calibration failed on {} channel — "
-                                      "check exposure spread and sample count",
-                                      makehdr::label, "RGB"[c]);
-                });
-            }
-            else if (_solver_type == 1)
-            {
-                threads[c] = std::thread([this, c]() {
-                    bool success = makehdr::robertson_solver<ptype, OFX::Image>(c,
-                                                            _input_depth,
-                                                            static_cast<int>(_smoothness),
-                                                            _sources,
-                                                            _effect.sample_points(),
-                                                            _exp_times,
-                                                            _effect.input_weights(),
-                                                            _effect.response(_input_depth, c));
-                    if (!success)
-                        spdlog::error("{}: Robertson calibration failed on {} channel — "
-                                      "no sample points could be generated",
-                                      makehdr::label, "RGB"[c]);
-                });
-            }
+            _effect.sample_points() = makehdr::build_sample_points(_width, _height, _params.samples * 100);
+            const std::array<bool, CMP_MAX> results = makehdr::run_robertson_calibration<ptype, OFX::Image>(
+                _sources, _exp_times, _params,
+                _effect.input_weights(), _effect.sample_points(),
+                _effect.response(_params.depth, 0));
+            for (int c = 0; c < CMP_MAX; ++c)
+                if (!results[c])
+                {
+                    spdlog::error("{}: Robertson calibration failed on {} channel — "
+                                  "no sample points could be generated",
+                                  makehdr::label, "RGB"[c]);
+                    break;
+                }
         }
 
-        for (int c = 0; c < CMP_MAX; ++c)
-            threads[c].join();
-
-        if (_solver_type == 1)
-            average_robertson_curves();
+        // Rebuild the sample set for O(1) pixel lookup during rendering.
+        _effect.sample_set().clear();
+        for (const makehdr::point& p : _effect.sample_points())
+        {
+            _effect.sample_set().insert(p.key());
+            spdlog::debug("{}: Getting sample pos({}, {})", makehdr::label, p.x, p.y);
+        }
     }
 
     void calibrate_linear()
     {
         _effect.set_regen_calib(false);
-
-        for (int i = 0; i < _input_depth; ++i)
-            _effect.response_linear()[i] = std::log(i * (1.f / _input_depth));
-
-        _effect.response_linear()[0] = _effect.response_linear()[1];
+        makehdr::build_linear_response(_params.depth, _effect.response_linear());
     }
 
-    void average_robertson_curves()
-    {
-        /// Robertson runs per-channel independently, producing divergent curve shapes
-        /// on sparse linear data. Average them into one shared curve to eliminate tints,
-        /// then smooth to remove kinks from sparsely-sampled bins near highlights.
-        for (int m = 0; m < _input_depth; ++m)
-        {
-            double avg = 0.0;
-            for (int c = 0; c < CMP_MAX; ++c)
-                avg += _effect.response(_input_depth, c)[m];
-            avg /= CMP_MAX;
-            for (int c = 0; c < CMP_MAX; ++c)
-                _effect.response(_input_depth, c)[m] = avg;
-        }
-
-        /// 3 passes of box-filter smoothing approximates a Gaussian kernel,
-        /// handling broader plateau-type banding from sparsely-sampled highlight bins.
-        const int radius = 4;
-        const int passes = 3;
-        std::vector<double> smoothed(_input_depth);
-        for (int pass = 0; pass < passes; ++pass)
-        {
-            double* curve = _effect.response(_input_depth, 0);
-            for (int m = 0; m < _input_depth; ++m)
-            {
-                double sum = 0.0;
-                int count = 0;
-                for (int k = std::max(0, m - radius); k <= std::min(_input_depth - 1, m + radius); ++k)
-                {
-                    sum += curve[k];
-                    ++count;
-                }
-                smoothed[m] = sum / count;
-            }
-            for (int m = 0; m < _input_depth; ++m)
-                for (int c = 0; c < CMP_MAX; ++c)
-                    _effect.response(_input_depth, c)[m] = smoothed[m];
-        }
-    }
-
-    inline float lookup_response(int bin, int channel) const
-    {
-        return _calibrate
-            ? static_cast<float>(_effect.response(_input_depth, channel)[bin])
-            : static_cast<float>(_effect.response_linear()[bin]);
-    }
-
-    inline float luminance(float* rgb)
-    {
-        return 0.212671f * rgb[makehdr::channel::r] + 0.71516f * rgb[makehdr::channel::g] + 0.072169f * rgb[makehdr::channel::b];
-    }
-
-    int pixel_size() { return _width * _height * _components; }
+    int pixel_size() { return _width * _height * _params.channels; }
     void add_source(std::shared_ptr<OFX::Image> src_image) { _sources.push_back(src_image); }
     void add_exp_time(float val) { _exp_times.push_back(val); _exp_times_log.push_back(std::log(val)); }
     void set_resolution(const OfxRectI& window) { _width = window.x2 - window.x1; _height = window.y2 - window.y1; }
-    void set_response() { _effect.set_response_size(CMP_MAX, _input_depth); }
-    void set_linear_response() { _effect.set_response_linear_size(_input_depth); }
+    void set_response() { _effect.set_response_size(CMP_MAX, _params.depth); }
+    void set_linear_response() { _effect.set_response_linear_size(_params.depth); }
     
 private:
     int _width = 0;
     int _height = 0;
-    int _components = 0;
 
     makehdr::timer _timer;
+    makehdr::merge_params _params;
+
+    bool _show_samples = false;
 
     std::vector<float> _exp_times;
     std::vector<float> _exp_times_log;
     std::vector<std::shared_ptr<OFX::Image>> _sources;
-
-    float _exposure = 0;
-    float _gamma = 0;
-    float _highlights = 0;
-    bool _calibrate = false;
-    bool _show_samples = false;
-    int _samples = 0;
-    int _solver_type = 0;
-    float _smoothness = 0;
-    int _input_depth = 0;
-
-    float _luminance_max = 0;
-    bool _use_middle_gray = false;
-    float _middle_gray = 0;
 
     Effect<ptype>& _effect;
 };


### PR DESCRIPTION
Hi @sosoyan,

one last structural PR, which decouples the core algorithms from OFX for unit testing, debugging or even reuse. The patch extracts all merge and tone-mapping code out of `Processor<T>` into a new standalone `merge.h` header, leaving `processor.h` as a thin OFX adapter (406 to 190 lines) — now just lifecycle hooks, state management and parameter setup — which also makes it easier to follow IMHO.

What do you think?

---

As a proof of concept, I couldn't be bothered to rack my brain over unit tests this weekend, so I wrote a tiny command-line prototype using OpenImageIO: [makehdr-cli-1.4.0-macos-arm64.zip](https://github.com/user-attachments/files/28541195/makehdr-cli-1.4.0-macos-arm64.zip). Pretty sure this is useful for testing captured images directly on-set too, using any sleepy machine. If you have the time and want to test it:

```sh
# Make sure OpenImageIO is installed
brew install openimageio

#  Pass the images and enable logging
makehdr test/images/*.jpg --verbose 
```

<img width="1639" height="737" alt="Screenshot 2026-06-02 at 22 35 56" src="https://github.com/user-attachments/assets/2c9409b9-feeb-414f-958f-31a835e08b94" />

Would love to hear your thoughts on this. Do you think this is a nice addition and worth pursuing?

Cheers,
Christian

